### PR TITLE
[18] Handle transitive dependencies in frameworks

### DIFF
--- a/CFNetwork/Makefile
+++ b/CFNetwork/Makefile
@@ -14,7 +14,10 @@ INCS= \
 	CFSocketStream.h
 
 RESOURCES=Info.plist English.lproj
-CFLAGS+= ${FMWK_CFLAGS} -I.. -I../libobjc2 \
-	 -F${BUILDROOT}/System/Library/Frameworks -framework Foundation
+CFLAGS+= ${FMWK_CFLAGS} -I.. -I../libobjc2 -I../Foundation/Headers \
+	-F${BUILDROOT}/System/Library/Frameworks -framework CoreFoundation
+LDFLAGS+=-L${BUILDROOT}/System/Library/Frameworks/CoreFoundation.framework/Versions/Current \
+	-lCoreFoundation \
+	-Wl,-R/System/Library/Frameworks/CoreFoundation.framework/Versions/A
 
 .include <he.framework.mk>

--- a/CoreFoundation/Makefile
+++ b/CoreFoundation/Makefile
@@ -84,7 +84,7 @@ INCS= \
 	CoreFoundation.h
 
 RESOURCES=Info.plist English.lproj
-CFLAGS+= ${FMWK_CFLAGS} -I.. -I../libobjc2 \
+CFLAGS+= ${FMWK_CFLAGS} -I.. -I../libobjc2 -I../Foundation/Headers \
 	 -F${BUILDROOT}/System/Library/Frameworks -framework Foundation
 
 .include <he.framework.mk>

--- a/Foundation/Makefile
+++ b/Foundation/Makefile
@@ -670,7 +670,11 @@ INCS= \
 RESOURCES=Info.plist English.lproj
 CFLAGS+= ${FMWK_CFLAGS} -I${.CURDIR}/Headers \
 	 -I${.CURDIR}/.. -I${BUILDROOT}/usr/include 
-LDFLAGS+= ${FMWK_LDFLAGS}
+LDFLAGS+= ${FMWK_LDFLAGS} \
+	  -Wl,-R/System/Library/Frameworks/CFNetwork.framework/Versions/A \
+	  -L${BUILDROOT}/System/Library/Frameworks/CFNetwork.framework/Versions/Current \
+	  -lCFNetwork \
+	  -lobjc -lunwind -lpthread
 
 build: marshallheaders all
 

--- a/Makefile
+++ b/Makefile
@@ -105,33 +105,39 @@ frameworksclean:
 	rm -rf ${BUILDROOT}/System/Library/Frameworks/*.framework
 	for fmwk in ${.ALLTARGETS:M*.framework:R}; do \
 		make ${MKINCDIR} -C $$fmwk clean; \
+		rm -rf $$fmwk/$$fmwk.framework; \
 	done
+	rm -rf Foundation/Headers
 
 frameworks: 
 	for fmwk in ${.ALLTARGETS:M*.framework}; do \
 		make ${MKINCDIR} $$fmwk; done
 
-Foundation.framework:
-	rm -rf Foundation/${.TARGET}
-	make -C Foundation BUILDROOT=${BUILDROOT} clean build
-	cp -Rvf ${TOPDIR}/${.TARGET:R}/${.TARGET} ${BUILDROOT}/System/Library/Frameworks
+marshallheaders:
+	make -C Foundation marshallheaders
 
-CoreFoundation.framework:
+# DO NOT change the order of these 4 frameworks!
+CoreFoundation.framework: marshallheaders
 	rm -rf CoreFoundation/${.TARGET}
 	make -C CoreFoundation BUILDROOT=${BUILDROOT} clean
 	make -C CoreFoundation BUILDROOT=${BUILDROOT}
-	cp -Rvf ${TOPDIR}/${.TARGET:R}/${.TARGET} ${BUILDROOT}/System/Library/Frameworks
-
-CoreServices.framework:
-	rm -rf CoreServices/${.TARGET}
-	make -C CoreServices BUILDROOT=${BUILDROOT} clean
-	make -C CoreServices BUILDROOT=${BUILDROOT}
 	cp -Rvf ${TOPDIR}/${.TARGET:R}/${.TARGET} ${BUILDROOT}/System/Library/Frameworks
 
 CFNetwork.framework:
 	rm -rf CFNetwork/${.TARGET}
 	make -C CFNetwork BUILDROOT=${BUILDROOT} clean
 	make -C CFNetwork BUILDROOT=${BUILDROOT}
+	cp -Rvf ${TOPDIR}/${.TARGET:R}/${.TARGET} ${BUILDROOT}/System/Library/Frameworks
+
+Foundation.framework:
+	rm -rf Foundation/${.TARGET}
+	make -C Foundation BUILDROOT=${BUILDROOT} clean build
+	cp -Rvf ${TOPDIR}/${.TARGET:R}/${.TARGET} ${BUILDROOT}/System/Library/Frameworks
+
+CoreServices.framework:
+	rm -rf CoreServices/${.TARGET}
+	make -C CoreServices BUILDROOT=${BUILDROOT} clean
+	make -C CoreServices BUILDROOT=${BUILDROOT}
 	cp -Rvf ${TOPDIR}/${.TARGET:R}/${.TARGET} ${BUILDROOT}/System/Library/Frameworks
 
 helium-package:

--- a/examples/app/Makefile
+++ b/examples/app/Makefile
@@ -25,8 +25,6 @@ APP=Bar
 SRCS=bar.m
 MK_DEBUG_FILES=no
 RESOURCES=rsc/sample.txt
-FRAMEWORKS=/System/Library/Frameworks/Foundation \
-	   /System/Library/Frameworks/CoreFoundation \
-	   /System/Library/Frameworks/CFNetwork
+FRAMEWORKS=/System/Library/Frameworks/Foundation
 
 .include <he.app.mk>

--- a/mk/internal/framework.common.mk
+++ b/mk/internal/framework.common.mk
@@ -2,5 +2,5 @@
 FMWK_CFLAGS := -O0 -g -D__HELIUM__ -DBSD -DPLATFORM_IS_POSIX -DGCC_RUNTIME_3 \
 	 -DPLATFORM_USES_BSD_SOCKETS -fobjc-runtime=gnustep-2.0 \
 	 -fobjc-nonfragile-abi -fPIC
-FMWK_LDFLAGS+= -L${BUILDROOT}/usr/lib -L/usr/lib -lobjc -lunwind -lpthread
+FMWK_LDFLAGS+= -L${BUILDROOT}/usr/lib -L/usr/lib -Wl,--no-as-needed
 


### PR DESCRIPTION
This change adds DT_RUNPATH and DT_NEEDED entries to a framework's DSO for any frameworks it depends on. These are then resolved by ld-elf when loading an executable that is linked to a framework.
Fixes #18 